### PR TITLE
update dashboard nav to stick to top of window

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ export default function App() {
           <h1>Loading...</h1>
         ) : (
           <div id="no-owlbear">
-            <PopOver />
+            <PopOver standalone={true} />
           </div>
         )}
       </>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -19,6 +19,7 @@ export default function Dashboard(props: DashboardProps) {
     selectADashboard,
     createADashboard,
     deleteADashboard,
+    standalone
   } = props;
   const [isLocked, setIsLocked] = useState(false);
   const [deleteZoneIsOpen, setDeleteZoneIsOpen] = useState(false);
@@ -72,8 +73,8 @@ export default function Dashboard(props: DashboardProps) {
   };
 
   return (
-    <div className="dashboard" id={isLocked ? "locked-dash" : "unlocked-dash"}>
-      <div className={styles["dashboard-nav"]}>
+    <div className={styles["dashboard"]} id={isLocked ? "locked-dash" : "unlocked-dash"}>
+      <div className={`${styles["dashboard-nav"]} ${standalone ? styles["dashboard-nav--standalone"] : ''}`}>
         <button
           className="icon-button"
           title="Go Back"
@@ -114,13 +115,12 @@ export default function Dashboard(props: DashboardProps) {
           <img src={download} alt="Download Icon" />
         </button>
       </div>
-      <div className={styles["dashboard-nav-header"]}>
+      <div className={`${styles["dashboard-nav-header"]} ${standalone ? styles["dashboard-nav-header--standalone"] : ''}`}>
         <h2>{selectedDashboard}</h2>
       </div>
       <div
-        className={`${styles["dashboard-delete-zone"]} ${
-          deleteZoneIsOpen ? styles["show-delete-zone"] : ""
-        }`}
+        className={`${styles["dashboard-delete-zone"]} ${deleteZoneIsOpen ? styles["show-delete-zone"] : ""
+          }`}
       >
         <p>Type "DELETE" to delete this dashboard permanently.</p>
         <div className={styles["dashboard-delete-zone-confirm"]}>
@@ -135,9 +135,8 @@ export default function Dashboard(props: DashboardProps) {
       </div>
 
       <div
-        className={`${styles["dashboard-duplicate-zone"]} ${
-          duplicateZoneIsOpen ? styles["show-duplicate-zone"] : ""
-        }`}
+        className={`${styles["dashboard-duplicate-zone"]} ${duplicateZoneIsOpen ? styles["show-duplicate-zone"] : ""
+          }`}
       >
         <p>Clone this dashboard by typing in a new name for the duplicate.</p>
         <div className={styles["dashboard-duplicate-zone-confirm"]}>

--- a/src/components/PopOver.tsx
+++ b/src/components/PopOver.tsx
@@ -10,6 +10,7 @@ import type {
   DashboardItemsProps,
   NewDashboardTemplateOptions,
   PremadeDashConfig,
+  PopOverProps
 } from "../types/index.ts";
 import Dashboard from "./Dashboard";
 
@@ -48,7 +49,7 @@ async function checkAndAddPremades(keys: string[]) {
   return newPremades;
 }
 
-export default function PopOver() {
+export default function PopOver({ standalone = false }: PopOverProps) {
   const [selectedDashboard, setSelectedDashboard] = useState("");
   const [dashBoardsArray, setDashboardsArray] = useState<string[]>([]);
   const [refreshCount, setRefreshCount] = useState(0);
@@ -201,6 +202,7 @@ export default function PopOver() {
           selectADashboard={selectADashboard}
           createADashboard={createADashboard}
           selectedDashboard={selectedDashboard}
+          standalone={standalone}
         />
       ) : (
         <>

--- a/src/styles/Dashboard.module.css
+++ b/src/styles/Dashboard.module.css
@@ -1,7 +1,24 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+}
+
 .dashboard-nav {
   display: flex;
+  align-self: center;
   align-items: center;
   justify-content: space-between;
+  position: fixed;
+  background: #242424;
+  width: 97.5vw;
+  z-index: 1;
+  padding: 8px 0px 12px 0px;
+  margin-top: -8px;
+}
+
+.dashboard-nav--standalone {
+  width: 631px;
+  position: relative;
 }
 
 .dashboard-nav *:first-child {
@@ -51,4 +68,9 @@
 .dashboard-nav-header {
   display: flex;
   justify-content: flex-start;
+  margin-top: 50px;
+}
+
+.dashboard-nav-header--standalone {
+  margin-top: 0;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ export type DashboardProps = {
     duplicateDashInputRef?: React.RefObject<HTMLInputElement>,
     contentToDuplicate?: DashboardItemsProps,
   ) => Promise<void>;
+  standalone: boolean;
 };
 
 export type SyncingGridProps = {
@@ -30,5 +31,9 @@ export type PremadeDashConfig = {
   fileName: string;
   dashName: string;
 };
+
+export type PopOverProps = {
+  standalone?: boolean;
+}
 
 export type NewDashboardTemplateOptions = "default" | "5eChar" | "duplicate";


### PR DESCRIPTION
This PR:
- Updates the nav on Dashboards to be fixed to the top of the window, so that you don't have to scroll all the way back up if your dashboard is quite long 😄 