### PR TITLE
create app store and add Dashboard Search functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ For more information on the full list of dice notation syntax that Dashboard Mak
 
 For Players, your roll is shared automatically.
 
+## Dashboard Searching
+
+Dashboard Maker now comes with an option to tie a token to a dashboard. It's pretty simple: if you have a dashboard named "Boblin" and you also have a token that you've added and named "Boblin", you can use the Dashboard Search option in the token's menu to automatically bring up that dashboard with the matching name.
+
+<img src="./docs/DashboardSearchExample.gif" alt="Dashboard Maker Search Example" width="722">
+
+Please note: The token name and the dasboard name must be an exact match for this feature to work.
+
 ## Images
 
 Dashboard Maker now supports adding images inside a dashboard content box.

--- a/docs/store.md
+++ b/docs/store.md
@@ -78,6 +78,14 @@ For more information on the full list of dice notation syntax that Dashboard Mak
 
 For Players, your roll is shared automatically.
 
+## Dashboard Searching
+
+Dashboard Maker now comes with an option to tie a token to a dashboard. It's pretty simple: if you have a dashboard named "Boblin" and you also have a token that you've added and named "Boblin", you can use the Dashboard Search option in the token's menu to automatically bring up that dashboard with the matching name.
+
+<img src="https://raw.githubusercontent.com/RobertTate/dashboard-maker/main/docs/DashboardSearchExample.gif" alt="Dashboard Maker Search Example" width="722">
+
+Please note: The token name and the dasboard name must be an exact match for this feature to work.
+
 ## Images
 
 Dashboard Maker now supports adding images inside a dashboard content box.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,12 @@
-import OBR, { type Image } from "@owlbear-rodeo/sdk";
+import OBR from "@owlbear-rodeo/sdk";
 import { useEffect, useState } from "react";
-import db from "./dbInstance";
 import PopOver from "./components/PopOver";
-import { useDice } from "./functions/hooks";
-import { useAppStore } from "./AppProvider";
+import { useDice, useDashboardSearch } from "./functions/hooks";
 import { Role } from "./types";
 
 export default function App() {
   const [appIsReady, setAppIsReady] = useState(false);
   const [role, setRole] = useState<Role>(undefined);
-  const { selectADashboard } = useAppStore();
 
   useEffect(() => {
     const initDashboardMaker = async () => {
@@ -18,56 +15,12 @@ export default function App() {
       setAppIsReady(true);
     };
 
-    // Dashboard Search
-    const setupContextMenu = () => {
-      OBR.contextMenu.create({
-        id: `com.roberttate.dashboard-maker-search-context-menu`,
-        icons: [
-          {
-            icon: "/icon.svg",
-            label: "Dashboard Search",
-            filter: {
-              every: [{ key: "type", value: "IMAGE" }],
-            },
-          },
-        ],
-        onClick: async (context) => {
-          const isImageItemType = context?.items?.[0]?.type === "IMAGE";
-          if (isImageItemType) {
-            const imageItem = context?.items?.[0] as Image;
-            const givenTokenName = imageItem?.text?.plainText || "";
-            const keys = await db.keys();
-            if (keys.includes(givenTokenName)) {
-              selectADashboard("");
-              selectADashboard(givenTokenName);
-              await OBR.action.open();
-            } else if (givenTokenName === "") {
-              await OBR.notification.show(
-                `No Dashboard found. Give this token a name that matches a dashboard first!`,
-                "ERROR",
-              );
-            } else {
-              await OBR.notification.show(
-                `No Dashboard found by that name.`,
-                "ERROR",
-              );
-            }
-          } else {
-            await OBR.notification.show(
-              `That token type doesn't work for dashboard searching. Sorry!`,
-              "ERROR",
-            );
-          }
-        },
-      });
-    };
-
     OBR.onReady(() => {
       initDashboardMaker();
-      setupContextMenu();
     });
   }, []);
 
+  useDashboardSearch();
   useDice();
 
   if (appIsReady) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,15 @@
-import OBR from "@owlbear-rodeo/sdk";
+import OBR, { type Image } from "@owlbear-rodeo/sdk";
 import { useEffect, useState } from "react";
-
+import db from "./dbInstance";
 import PopOver from "./components/PopOver";
 import { useDice } from "./functions/hooks";
+import { useAppStore } from "./AppProvider";
 import { Role } from "./types";
 
 export default function App() {
   const [appIsReady, setAppIsReady] = useState(false);
   const [role, setRole] = useState<Role>(undefined);
+  const { selectADashboard } = useAppStore();
 
   useEffect(() => {
     const initDashboardMaker = async () => {
@@ -16,8 +18,53 @@ export default function App() {
       setAppIsReady(true);
     };
 
+    // Dashboard Search
+    const setupContextMenu = () => {
+      OBR.contextMenu.create({
+        id: `com.roberttate.dashboard-maker-search-context-menu`,
+        icons: [
+          {
+            icon: "/icon.svg",
+            label: "Dashboard Search",
+            filter: {
+              every: [{ key: "type", value: "IMAGE" }],
+            },
+          },
+        ],
+        onClick: async (context) => {
+          const isImageItemType = context?.items?.[0]?.type === "IMAGE";
+          if (isImageItemType) {
+            const imageItem = context?.items?.[0] as Image;
+            const givenTokenName = imageItem?.text?.plainText || "";
+            const keys = await db.keys();
+            if (keys.includes(givenTokenName)) {
+              selectADashboard("");
+              selectADashboard(givenTokenName);
+              await OBR.action.open();
+            } else if (givenTokenName === "") {
+              await OBR.notification.show(
+                `No Dashboard found. Give this token a name that matches a dashboard first!`,
+                "ERROR",
+              );
+            } else {
+              await OBR.notification.show(
+                `No Dashboard found by that name.`,
+                "ERROR",
+              );
+            }
+          } else {
+            await OBR.notification.show(
+              `That token type doesn't work for dashboard searching. Sorry!`,
+              "ERROR",
+            );
+          }
+        },
+      });
+    };
+
     OBR.onReady(() => {
       initDashboardMaker();
+      setupContextMenu();
     });
   }, []);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import OBR from "@owlbear-rodeo/sdk";
 import { useEffect, useState } from "react";
+
 import PopOver from "./components/PopOver";
-import { useDice, useDashboardSearch } from "./functions/hooks";
+import { useDashboardSearch, useDice } from "./functions/hooks";
 import { Role } from "./types";
 
 export default function App() {

--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useState, useCallback } from "react";
+import type { AppContextProps, AppProviderProps } from "./types";
+
+const AppContext = createContext<AppContextProps | undefined>(
+  undefined
+);
+
+export const useAppStore = () => {
+  const context = useContext(AppContext);
+  if (!context) throw new Error("Context Hasn't Been Set!");
+  return context;
+}
+
+export const AppProvider: React.FC<AppProviderProps> = ({
+  children
+}) => {
+  const [selectedDashboard, setSelectedDashboard] = useState("");
+  const selectADashboard = useCallback((dashName: string) => {
+    setSelectedDashboard(dashName);
+  }, []);
+
+  const store: AppContextProps = {
+    selectedDashboard,
+    selectADashboard,
+  };
+
+  return (
+    <AppContext.Provider value={store}>
+      {children}
+    </AppContext.Provider>
+  )
+}

--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -1,19 +1,16 @@
-import { createContext, useContext, useState, useCallback } from "react";
+import { createContext, useCallback, useContext, useState } from "react";
+
 import type { AppContextProps, AppProviderProps } from "./types";
 
-const AppContext = createContext<AppContextProps | undefined>(
-  undefined
-);
+const AppContext = createContext<AppContextProps | undefined>(undefined);
 
 export const useAppStore = () => {
   const context = useContext(AppContext);
   if (!context) throw new Error("Context Hasn't Been Set!");
   return context;
-}
+};
 
-export const AppProvider: React.FC<AppProviderProps> = ({
-  children
-}) => {
+export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
   const [selectedDashboard, setSelectedDashboard] = useState("");
   const selectADashboard = useCallback((dashName: string) => {
     setSelectedDashboard(dashName);
@@ -24,9 +21,5 @@ export const AppProvider: React.FC<AppProviderProps> = ({
     selectADashboard,
   };
 
-  return (
-    <AppContext.Provider value={store}>
-      {children}
-    </AppContext.Provider>
-  )
-}
+  return <AppContext.Provider value={store}>{children}</AppContext.Provider>;
+};

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { memo, useCallback, useRef, useState } from "react";
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
 
+import { useAppStore } from "../AppProvider";
 import download from "../assets/download.svg";
 import duplicate from "../assets/duplicate.svg";
 import fire from "../assets/fire.svg";
@@ -23,14 +24,8 @@ import ColumnToggle from "./ColumnToggle";
 import SyncingGrid from "./SyncingGrid";
 
 const Dashboard = memo((props: DashboardProps) => {
-  const {
-    selectedDashboard,
-    selectADashboard,
-    createADashboard,
-    deleteADashboard,
-    standalone,
-    role,
-  } = props;
+  const { createADashboard, deleteADashboard, standalone, role } = props;
+  const { selectedDashboard, selectADashboard } = useAppStore();
   const [isLocked, setIsLocked] = useState(false);
   const [columns, setColumns] = useState(8);
   const [deleteZoneIsOpen, setDeleteZoneIsOpen] = useState(false);

--- a/src/components/DashboardFileSystem.tsx
+++ b/src/components/DashboardFileSystem.tsx
@@ -6,6 +6,7 @@ import ReactGridLayout, {
   WidthProvider,
 } from "react-grid-layout";
 
+import { useAppStore } from "../AppProvider";
 import {
   collisionInfo,
   createMenuItems,
@@ -20,11 +21,11 @@ const DashboardFileSystem = memo(
   ({
     dashBoardsArray,
     menuObject,
-    selectADashboard,
     setMenuObject,
     setSyncStorage,
   }: DashboardFileSystemProps) => {
     if (!menuObject) return null;
+    const { selectADashboard } = useAppStore();
     const folderRefs = useRef<HTMLDivElement[]>([]);
     const folderUpBtnRef = useRef<HTMLButtonElement | null>(null);
     const ResponsiveReactGridLayout = useMemo(

--- a/src/components/PopOver.tsx
+++ b/src/components/PopOver.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useRef, useState } from "react";
 
+import { useAppStore } from "../AppProvider.tsx";
 import dashboard from "../assets/dashboard.svg";
 import refresh from "../assets/refresh.svg";
 import upload from "../assets/upload.svg";
@@ -23,7 +24,8 @@ import DashboardFileSystem from "./DashboardFileSystem.tsx";
 import { FolderCreator } from "./FolderCreator";
 
 const PopOver = memo(({ standalone = false, role }: PopOverProps) => {
-  const [selectedDashboard, setSelectedDashboard] = useState("");
+  const { selectedDashboard, selectADashboard } = useAppStore();
+
   const [dashBoardsArray, setDashboardsArray] = useState<string[]>([]);
   const [menuObject, setMenuObject] = useState<MenuObject>({
     folders: {},
@@ -36,10 +38,6 @@ const PopOver = memo(({ standalone = false, role }: PopOverProps) => {
 
   const [syncStorage, setSyncStorage] = useState(0);
   useSyncStorage(syncStorage, menuObject);
-
-  const selectADashboard = useCallback((dashName: string) => {
-    setSelectedDashboard(dashName);
-  }, []);
 
   useReceiveDashboard(standalone, setRefreshCount, selectADashboard);
   useShowDiceResults(standalone);
@@ -211,9 +209,7 @@ const PopOver = memo(({ standalone = false, role }: PopOverProps) => {
       {selectedDashboard ? (
         <Dashboard
           deleteADashboard={deleteADashboard}
-          selectADashboard={selectADashboard}
           createADashboard={createADashboard}
-          selectedDashboard={selectedDashboard}
           standalone={standalone}
           role={role}
         />
@@ -309,7 +305,6 @@ const PopOver = memo(({ standalone = false, role }: PopOverProps) => {
               dashBoardsArray={dashBoardsArray}
               menuObject={menuObject}
               setMenuObject={setMenuObject}
-              selectADashboard={selectADashboard}
               setSyncStorage={setSyncStorage}
             />
           </div>

--- a/src/components/SyncingGrid.tsx
+++ b/src/components/SyncingGrid.tsx
@@ -80,7 +80,7 @@ const SyncingGrid = memo(
         });
       };
       getSavedItems();
-    }, []);
+    }, [dashName]);
 
     useEffect(() => {
       const updateLayouts = async () => {

--- a/src/functions/hooks/index.ts
+++ b/src/functions/hooks/index.ts
@@ -4,3 +4,4 @@ export { useReceiveDashboard } from "./useReceiveDashboard";
 export { useInitDashboards } from "./useInitDashboards";
 export { useFixLayout } from "./useFixLayout";
 export { useSyncStorage } from "./useSyncStorage";
+export { useDashboardSearch } from "./useDashboardSearch";

--- a/src/functions/hooks/useDashboardSearch.ts
+++ b/src/functions/hooks/useDashboardSearch.ts
@@ -1,4 +1,4 @@
-import OBR, { type Image } from "@owlbear-rodeo/sdk";
+import OBR, { isImage } from "@owlbear-rodeo/sdk";
 import { useEffect } from "react";
 
 import { useAppStore } from "../../AppProvider";
@@ -21,9 +21,8 @@ export const useDashboardSearch = () => {
           },
         ],
         onClick: async (context) => {
-          const isImageItemType = context?.items?.[0]?.type === "IMAGE";
-          if (isImageItemType) {
-            const imageItem = context?.items?.[0] as Image;
+          if (isImage(context?.items?.[0])) {
+            const imageItem = context?.items?.[0];
             const givenTokenName = imageItem?.text?.plainText || "";
             const keys = await db.keys();
             if (givenTokenName === selectedDashboard) {

--- a/src/functions/hooks/useDashboardSearch.ts
+++ b/src/functions/hooks/useDashboardSearch.ts
@@ -39,7 +39,7 @@ export const useDashboardSearch = () => {
             } else if (givenTokenName === "") {
               await OBR.player.deselect();
               await OBR.notification.show(
-                `No Dashboard found. Give this token a name that matches a dashboard first!`,
+                `No Dashboard found. Token must have a name to match a dashboard!`,
                 "ERROR",
               );
             } else {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,12 +5,15 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 import App from "./App.tsx";
+import { AppProvider } from "./AppProvider.tsx";
 import "./dbInstance.ts";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <AppProvider>
+      <App />
+    </AppProvider>
     <Analytics />
     <SpeedInsights />
   </React.StrictMode>,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,8 @@
+import { ReactElement } from "react";
+
 export type Role = "GM" | "PLAYER" | undefined;
 
 export type DashboardProps = {
-  selectedDashboard: string;
-  selectADashboard: (dashboardId: string) => void;
   deleteADashboard: (dashName: string) => Promise<void>;
   createADashboard: (
     template: NewDashboardTemplateOptions,
@@ -85,7 +85,6 @@ export type DashboardFileSystemProps = {
   dashBoardsArray: string[];
   menuObject: MenuObject;
   setMenuObject: React.Dispatch<React.SetStateAction<MenuObject>>;
-  selectADashboard: (dashName: string) => void;
   setSyncStorage: React.Dispatch<React.SetStateAction<number>>;
 };
 
@@ -93,4 +92,13 @@ export type FolderCreatorProps = {
   menuObject: MenuObject;
   setMenuObject: React.Dispatch<React.SetStateAction<MenuObject>>;
   setSyncStorage: React.Dispatch<React.SetStateAction<number>>;
+};
+
+export type AppContextProps = {
+  selectedDashboard: string;
+  selectADashboard: (dashName: string) => void;
+};
+
+export type AppProviderProps = {
+  children: ReactElement | ReactElement[];
 };


### PR DESCRIPTION
This PR:
- Create a Provider for the app, lifting up the dashboard selection function so that it's easier to select a dashboard from anywhere in the app
- Adds to the context menu, a "Dashboard Search" option, that when you click a toke with a given name that matches a dashboard name, that specific dashboard will open.