### PR TITLE
brighten dice mod colors and fix download file type issue

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -121,7 +121,7 @@ const Dashboard = memo((props: DashboardProps) => {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = selectedDashboard;
+      a.download = `${selectedDashboard}.json`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/src/index.css
+++ b/src/index.css
@@ -485,13 +485,13 @@ button:active {
 
 #dice-box .displayResults .results .mod-positive,
 #dice-box .displayResults .results .mod-multiply {
-  color: #027002;
+  color: #0ad666;
   font-size: 1.25rem;
 }
 
 #dice-box .displayResults .results .mod-negative,
 #dice-box .displayResults .results .mod-divide {
-  color: #b70000;
+  color: #ff4848;
   font-size: 1.25rem;
 }
 


### PR DESCRIPTION
This PR:
- Brightens up the dice modifier colors so that they are easier to see.
- Fixes an issue where apparently some Os's and/or chrome versions were causing dashboard downloads to have a `.customization` file extension instead of the desired `.json` file extension. Explicitly setting the file extension in the `download` param string fixes it.