### PR TITLE
Dash sharing menu fix

### DIFF
--- a/src/components/PopOver.tsx
+++ b/src/components/PopOver.tsx
@@ -39,7 +39,7 @@ const PopOver = memo(({ standalone = false, role }: PopOverProps) => {
   const [syncStorage, setSyncStorage] = useState(0);
   useSyncStorage(syncStorage, menuObject);
 
-  useReceiveDashboard(standalone, setRefreshCount, selectADashboard);
+  useReceiveDashboard(standalone, setRefreshCount, selectADashboard, setMenuObject);
   useShowDiceResults(standalone);
   useInitDashboards(refreshCount, setDashboardsArray, setMenuObject);
 

--- a/src/functions/folderFunctions.ts
+++ b/src/functions/folderFunctions.ts
@@ -1,3 +1,4 @@
+import { MdxNodeType } from "@mdxeditor/editor";
 import type { Folder, FolderSystem, MenuObject } from "../types";
 
 export const getCurrentFolder = (menuObject: MenuObject) => {
@@ -41,10 +42,10 @@ export const getSurroundings = (menuObject: MenuObject) => {
   };
 };
 
-const recursiveFind = (folder: Folder, cumulativeDashes: string[]) => {
+const recursiveFindFolders = (folder: Folder, cumulativeDashes: string[]) => {
   if (folder.folders) {
     for (const subfolder in folder.folders) {
-      cumulativeDashes = recursiveFind(
+      cumulativeDashes = recursiveFindFolders(
         folder.folders[subfolder],
         cumulativeDashes,
       );
@@ -57,7 +58,27 @@ const recursiveFind = (folder: Folder, cumulativeDashes: string[]) => {
 export const findAllDashboardsWithinCurrentFolderStruc = (
   currentFolder: Folder,
 ) => {
-  const allDashboards: string[] = recursiveFind(currentFolder, []);
-
+  const allDashboards: string[] = recursiveFindFolders(currentFolder, []);
   return allDashboards;
 };
+
+
+const recursiveFindDashboard = (folder: MenuObject | Folder, dashName: string) => {
+  if (folder.dashboards?.includes(dashName)) {
+    return folder;
+  }
+  if (folder.folders) {
+    for (const subfolder in folder.folders) {
+      return recursiveFindDashboard(folder.folders[subfolder], dashName)
+    }
+  }
+  return null;
+}
+
+export const getFolderOfSpecificDashboard = (
+  menuObject: MenuObject,
+  dashName: string,
+) => {
+  const folderOfDashboard: MenuObject | Folder | null = recursiveFindDashboard(menuObject, dashName);
+  return folderOfDashboard;
+}

--- a/src/functions/folderFunctions.ts
+++ b/src/functions/folderFunctions.ts
@@ -41,10 +41,10 @@ export const getSurroundings = (menuObject: MenuObject) => {
   };
 };
 
-const recursiveFindFolders = (folder: Folder, cumulativeDashes: string[]) => {
+const recursiveSearchFoldersForDashboards = (folder: Folder, cumulativeDashes: string[]) => {
   if (folder.folders) {
     for (const subfolder in folder.folders) {
-      cumulativeDashes = recursiveFindFolders(
+      cumulativeDashes = recursiveSearchFoldersForDashboards(
         folder.folders[subfolder],
         cumulativeDashes,
       );
@@ -57,18 +57,18 @@ const recursiveFindFolders = (folder: Folder, cumulativeDashes: string[]) => {
 export const findAllDashboardsWithinCurrentFolderStruc = (
   currentFolder: Folder,
 ) => {
-  const allDashboards: string[] = recursiveFindFolders(currentFolder, []);
+  const allDashboards: string[] = recursiveSearchFoldersForDashboards(currentFolder, []);
   return allDashboards;
 };
 
 
-const recursiveFindDashboard = (folder: MenuObject | Folder, dashName: string) => {
+const recursiveFindDashboardAcrossFolders = (folder: MenuObject | Folder, dashName: string) => {
   if (folder.dashboards?.includes(dashName)) {
     return folder;
   }
   if (folder.folders) {
     for (const subfolder in folder.folders) {
-      return recursiveFindDashboard(folder.folders[subfolder], dashName)
+      return recursiveFindDashboardAcrossFolders(folder.folders[subfolder], dashName)
     }
   }
   return null;
@@ -78,6 +78,6 @@ export const getFolderOfSpecificDashboard = (
   menuObject: MenuObject,
   dashName: string,
 ) => {
-  const folderOfDashboard: MenuObject | Folder | null = recursiveFindDashboard(menuObject, dashName);
+  const folderOfDashboard: MenuObject | Folder | null = recursiveFindDashboardAcrossFolders(menuObject, dashName);
   return folderOfDashboard;
 }

--- a/src/functions/folderFunctions.ts
+++ b/src/functions/folderFunctions.ts
@@ -1,4 +1,3 @@
-import { MdxNodeType } from "@mdxeditor/editor";
 import type { Folder, FolderSystem, MenuObject } from "../types";
 
 export const getCurrentFolder = (menuObject: MenuObject) => {

--- a/src/functions/folderFunctions.ts
+++ b/src/functions/folderFunctions.ts
@@ -60,24 +60,3 @@ export const findAllDashboardsWithinCurrentFolderStruc = (
   const allDashboards: string[] = recursiveSearchFoldersForDashboards(currentFolder, []);
   return allDashboards;
 };
-
-
-const recursiveFindDashboardAcrossFolders = (folder: MenuObject | Folder, dashName: string) => {
-  if (folder.dashboards?.includes(dashName)) {
-    return folder;
-  }
-  if (folder.folders) {
-    for (const subfolder in folder.folders) {
-      return recursiveFindDashboardAcrossFolders(folder.folders[subfolder], dashName)
-    }
-  }
-  return null;
-}
-
-export const getFolderOfSpecificDashboard = (
-  menuObject: MenuObject,
-  dashName: string,
-) => {
-  const folderOfDashboard: MenuObject | Folder | null = recursiveFindDashboardAcrossFolders(menuObject, dashName);
-  return folderOfDashboard;
-}

--- a/src/functions/hooks/useReceiveDashboard.ts
+++ b/src/functions/hooks/useReceiveDashboard.ts
@@ -41,7 +41,6 @@ export const useReceiveDashboard = (
             setMenuObject((prevMenuObj) => {
               const newMenuObj: MenuObject = structuredClone(prevMenuObj);
               const allDashboardsInThefolderSystem = findAllDashboardsWithinCurrentFolderStruc(newMenuObj);
-              console.log(allDashboardsInThefolderSystem);
               if (!allDashboardsInThefolderSystem.includes(sharedDashboardTitle)) {
                 const currentFolder = getCurrentFolder(newMenuObj);
                 if (!currentFolder?.dashboards) {

--- a/src/functions/hooks/useReceiveDashboard.ts
+++ b/src/functions/hooks/useReceiveDashboard.ts
@@ -4,11 +4,14 @@ import { useEffect } from "react";
 
 import db from "../../dbInstance";
 import type { SharedDashboard } from "../../types";
+import type { MenuObject } from "../../types";
+import { getCurrentFolder, findAllDashboardsWithinCurrentFolderStruc } from "../folderFunctions";
 
 export const useReceiveDashboard = (
   standalone: boolean,
   setRefreshCount: React.Dispatch<React.SetStateAction<number>>,
   selectADashboard: (dashName: string) => void,
+  setMenuObject: React.Dispatch<React.SetStateAction<MenuObject>>,
 ) => {
   useEffect(() => {
     if (standalone === false) {
@@ -35,6 +38,20 @@ export const useReceiveDashboard = (
               sharedDashboard;
             await db.setItem(sharedDashboardTitle, sharedDashboardContent);
             setRefreshCount((prev) => prev + 1);
+            setMenuObject((prevMenuObj) => {
+              const newMenuObj: MenuObject = structuredClone(prevMenuObj);
+              const allDashboardsInThefolderSystem = findAllDashboardsWithinCurrentFolderStruc(newMenuObj);
+              console.log(allDashboardsInThefolderSystem);
+              if (!allDashboardsInThefolderSystem.includes(sharedDashboardTitle)) {
+                const currentFolder = getCurrentFolder(newMenuObj);
+                if (!currentFolder?.dashboards) {
+                  currentFolder.dashboards = [];
+                }
+                currentFolder.dashboards.push(sharedDashboardTitle);
+                return newMenuObj;
+              }
+              return prevMenuObj;
+            });
             selectADashboard("");
             await OBR.notification.show(
               `"${sharedDashboardTitle}" has just been shared with you!`,

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -5,6 +5,7 @@ export {
   getCurrentFolder,
   getSurroundings,
   findAllDashboardsWithinCurrentFolderStruc,
+  getFolderOfSpecificDashboard,
 } from "./folderFunctions";
 export { checkAndAddPremades, applyPremades } from "./premadesFunctions";
 export { collisionInfo } from "./collisions";

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -5,7 +5,6 @@ export {
   getCurrentFolder,
   getSurroundings,
   findAllDashboardsWithinCurrentFolderStruc,
-  getFolderOfSpecificDashboard,
 } from "./folderFunctions";
 export { checkAndAddPremades, applyPremades } from "./premadesFunctions";
 export { collisionInfo } from "./collisions";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,7 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    cors: true,
+  }
 });


### PR DESCRIPTION
This PR:
- Fixes an issue with the Dashboard sharing feature, where the new menu system wasn't integrated properly with this feature.
- Adds a `cors: true` property to a `server` property in vite's `defineConfig` object, which looks to be needed now for local owlbear rodeo development, after updating to a newer version of Vite.