### PR TITLE
no longer immediately open a newly created dash

### DIFF
--- a/src/components/PopOver.tsx
+++ b/src/components/PopOver.tsx
@@ -128,8 +128,6 @@ const PopOver = memo(({ standalone = false, role }: PopOverProps) => {
 
           if (duplicateDashInputRef) {
             selectADashboard("");
-          } else {
-            selectADashboard(dashName);
           }
         }
       } else {


### PR DESCRIPTION
This feature:

- Removes the functionality where when you would create a new dashboard, you would automatically navigate into opening it. Now, you stay where you are in the menu, but the new dashboard appears, and you can click it when you're ready to open it.

This also fixes a minor bug, where the menu state was not being auto-updated in IndexedDB until after the user navigates back out of the dashboard to the menu. Could cause weird issues with the Menu not updating properly.