### PR TITLE
Add theming with CSS variables

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,8 @@
+/*
+  No-Owlbear container styles.
+  Uses theme variables from theme.css: --bg controls background and --primary
+  colors accent interactive elements.
+*/
 #no-owlbear {
   display: flex;
   justify-content: center;
@@ -45,10 +50,10 @@ p {
 }
 
 :root {
-  background-color: #242424;
+  background-color: var(--bg);
   text-rendering: optimizelegibility;
   line-height: 1.5;
-  color: #fff;
+  color: var(--text);
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
@@ -69,27 +74,27 @@ button {
     background-color 0.25s;
   border: 3px solid transparent;
   border-radius: 8px;
-  background-color: #4c396e;
+  background-color: var(--surface);
   cursor: pointer;
   padding: 0.5rem;
   min-height: 38px;
   line-height: 0;
-  color: #fff;
+  color: var(--text);
   font-family: inherit;
   font-size: 1em;
   font-weight: 500;
 }
 
 button#fifth-edition-char {
-  background-color: #bf5d5d;
+  background-color: var(--danger);
 }
 
 button:hover {
-  border-color: #b9f;
+  border-color: var(--primary-light);
 }
 
 button:active {
-  background-color: #8447ff;
+  background-color: var(--primary);
 }
 
 .react-grid-layout {
@@ -97,7 +102,7 @@ button:active {
   border: 5px solid transparent;
   border-left: 3px solid transparent;
   border-radius: 8px;
-  background-color: #5f5f5f;
+  background-color: var(--grid-bg);
 }
 
 .react-grid-layout .react-grid-item {
@@ -106,15 +111,15 @@ button:active {
   justify-content: center;
   margin-top: -5px;
   margin-left: -5px;
-  border: 2px solid #ba98ff;
+  border: 2px solid var(--border);
   border-radius: 4px;
-  background-color: #3a3a3a;
+  background-color: var(--surface-alt);
   padding: 0.25rem;
 }
 
 .react-grid-item>.react-resizable-handle::after {
-  border-right: 2px solid #b9f;
-  border-bottom: 2px solid #b9f;
+  border-right: 2px solid var(--primary-light);
+  border-bottom: 2px solid var(--primary-light);
 }
 
 .react-grid-layout .react-grid-item #delete-widget {
@@ -145,7 +150,7 @@ button:active {
 }
 
 .editable-md-widget {
-  --basePageBg: #3a3a3a;
+  --basePageBg: var(--surface-alt);
   --admonitionTipBg: hsl(187deg 71% 88% / 50%);
   --admonitionTipBorder: hsl(189deg 60% 53% / 50%);
   --admonitionInfoBg: hsl(123deg 45% 90% / 50%);
@@ -158,7 +163,7 @@ button:active {
   --admonitionNoteBorder: hsl(231deg 10% 75% / 50%);
 
   padding: 0;
-  caret-color: #8447ff;
+  caret-color: var(--primary);
 }
 
 /* Border Radius of Admonitions */
@@ -182,18 +187,18 @@ button:active {
 
 /* Styling the Link Dialog */
 .mdxeditor-popup-container>div:has(div[class^="_linkDialogPopoverContent"])>div {
-  border: 3px solid #ba98ff;
-  background-color: #4c396e;
+  border: 3px solid var(--border);
+  background-color: var(--surface);
 }
 
 /* Style the displayed link in the Closed Link Dialog  */
 .mdxeditor-popup-container>div:has(div[class^="_linkDialogPopoverContent"])>div a[class^="_linkDialogPreviewAnchor"] {
-  color: #ba98ff;
+  color: var(--border);
 }
 
 /* Style the other icons in the Closed Link Dialog */
 .mdxeditor-popup-container>div:has(div[class^="_linkDialogPopoverContent"])>div button[class^="_actionButton"]>svg {
-  color: #ba98ff;
+  color: var(--border);
 }
 
 .mdxeditor-popup-container>div:has(div[class^="_linkDialogPopoverContent"])>div button[class^="_actionButton"] {
@@ -209,13 +214,13 @@ button:active {
 }
 
 .mdxeditor-popup-container>div:has(div[class^="_linkDialogPopoverContent"])>div a[class^="_linkDialogPreviewAnchor"]:hover {
-  border: 2px solid #ba98ff;
+  border: 2px solid var(--border);
 }
 
 
 /* Style the Text Labels in the Open Link Dialog */
 .mdxeditor-popup-container>div:has(div[class^="_linkDialogPopoverContent"]):has(form) label {
-  color: #d2bff9;
+  color: var(--link-dialog-label);
 }
 
 /* Style the button borders of the Open Link Dialog */
@@ -225,7 +230,7 @@ button:active {
 
 /* Style the background color of the submit button of the Open Link Dialog */
 .mdxeditor-popup-container>div:has(div[class^="_linkDialogPopoverContent"]):has(form) button[type="submit"] {
-  background-color: #8447ff;
+  background-color: var(--primary);
 }
 
 /* Remove the text highlighting when the link dialog is open. Wasn't lining up with the text correctly. */
@@ -238,20 +243,20 @@ button:active {
 .editable-md-widget span,
 .editable-md-widget strong,
 .editable-md-widget em {
-  color: #fff;
+  color: var(--white);
 }
 
 .editable-md-widget code span,
 .editable-md-widget code strong,
 .editable-md-widget code em {
-  color: #000;
+  color: var(--black);
 }
 
 .editable-md-widget blockquote {
   margin-top: 1.6em;
   margin-bottom: 1.6em;
   margin-left: 0.5em;
-  border-left: 3px solid #8447ff;
+  border-left: 3px solid var(--primary);
   padding-left: 1em;
   font-weight: 400;
   font-style: italic;
@@ -282,7 +287,7 @@ button:active {
 
 .editable-md-widget ul,
 .editable-md-widget ol {
-  color: #fff;
+  color: var(--white);
 }
 
 .editable-md-widget a {
@@ -293,28 +298,28 @@ button:active {
 .editable-md-widget a strong,
 .editable-md-widget a em {
   cursor: pointer;
-  color: #9773e4;
+  color: var(--link);
   font-weight: bold;
 }
 
 .editable-md-widget a span:hover,
 .editable-md-widget a strong:hover,
 .editable-md-widget a em:hover {
-  color: #c9b0ff;
+  color: var(--link-hover);
 }
 
 .editable-md-widget hr {
-  border-color: #ba98ff;
+  border-color: var(--border);
 }
 
 .editable-md-widget th,
 .editable-md-widget td {
-  --baseBgActive: #ba98ff;
+  --baseBgActive: var(--border);
 }
 
 .editable-md-widget li[role="checkbox"] {
-  --accentSolid: #8447ff;
-  --accentBorder: #ba98ff;
+  --accentSolid: var(--primary);
+  --accentBorder: var(--border);
 }
 
 *[class^="_tableEditor"] *[class^="_tableColumnEditorTrigger"],
@@ -330,15 +335,15 @@ button:active {
   align-items: center;
   justify-content: center;
   transition: background-color 0.25s;
-  background-color: #4c2696;
+  background-color: var(--primary-dark);
 }
 
 .react-grid-layout .react-grid-item#add-widget:hover {
-  background-color: #2b194f;
+  background-color: var(--primary-darker);
 }
 
 .react-grid-layout .react-grid-item#add-widget:active {
-  background-color: #8447ff;
+  background-color: var(--primary);
 }
 
 .react-grid-layout .react-grid-item#add-widget img {
@@ -385,7 +390,7 @@ button:active {
   position: absolute;
   top: 33px;
   border-radius: 50%;
-  background: #fff;
+  background: var(--white);
   width: 13px;
   height: 13px;
   animation-timing-function: cubic-bezier(0, 1, 1, 0);
@@ -455,9 +460,9 @@ button:active {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
-  border: 2px solid #ba98ff;
-  background: #4c2696;
-  color: #fff;
+  border: 2px solid var(--border);
+  background: var(--primary-dark);
+  color: var(--white);
 }
 
 #dice-result-sharing-box .displayResults .results {
@@ -471,8 +476,8 @@ button:active {
   position: absolute;
   top: -58px;
   left: -10px;
-  border: 2px solid #ba98ff;
-  background: #4c2696;
+  border: 2px solid var(--border);
+  background: var(--primary-dark);
   width: max-content;
   font-size: 0.75rem;
 }
@@ -481,9 +486,9 @@ button:active {
   position: absolute;
   top: -36px;
   left: -11px;
-  border: 2px solid #ba98ff;
+  border: 2px solid var(--border);
   border-radius: 8px;
-  background: #4c2696;
+  background: var(--primary-dark);
   padding: 0 0.5rem;
   width: max-content;
   font-size: 1rem;
@@ -491,7 +496,7 @@ button:active {
 
 #dice-box .displayResults .results button:hover,
 #dice-result-sharing-box .displayResults .results button:hover {
-  background: #8447ff;
+  background: var(--primary);
 }
 
 #dice-box .displayResults .results button img,
@@ -502,66 +507,66 @@ button:active {
 #dice-box .displayResults .results .dice-result-label,
 #dice-result-sharing-box .displayResults .results .dice-result-label {
   padding-left: 0.5rem;
-  color: #ffcf91;
+  color: var(--dice-label);
 }
 
 #dice-box .displayResults .results .mod-positive,
 #dice-box .displayResults .results .mod-multiply {
-  color: #0ad666;
+  color: var(--success);
   font-size: 1.25rem;
 }
 
 #dice-result-sharing-box .displayResults .results .mod-positive,
 #dice-result-sharing-box .displayResults .results .mod-multiply {
-  color: #0ad666;
+  color: var(--success);
   font-size: 1.25rem;
 }
 
 #dice-box .displayResults .results .mod-negative,
 #dice-box .displayResults .results .mod-divide {
-  color: #ff4848;
+  color: var(--danger);
   font-size: 1.25rem;
 }
 
 #dice-result-sharing-box .displayResults .results .mod-negative,
 #dice-result-sharing-box .displayResults .results .mod-divide {
-  color: #ff4848;
+  color: var(--danger);
   font-size: 1.25rem;
 }
 
 #dice-box .displayResults .results .crit-success,
 #dice-result-sharing-box .displayResults .results .crit-success {
-  color: #0ad666;
+  color: var(--success);
 }
 
 #dice-box .displayResults .results svg,
 #dice-result-sharing-box .displayResults .results svg {
-  fill: #dcf;
+  fill: var(--dice-fill);
 }
 
 #dice-box .displayResults .results .crit-success svg,
 #dice-result-sharing-box .displayResults .results .crit-success svg {
-  fill: #0ad666;
+  fill: var(--success);
 }
 
 #dice-box .displayResults .results .crit-failure,
 #dice-result-sharing-box .displayResults .results .crit-failure {
-  color: #ff4848;
+  color: var(--danger);
 }
 
 #dice-box .displayResults .results .crit-failure svg,
 #dice-result-sharing-box .displayResults .results .crit-failure svg {
-  fill: #ff4848;
+  fill: var(--danger);
 }
 
 #dice-box .displayResults .results strong[data-success="true"],
 #dice-result-sharing-box .displayResults .results strong[data-success="true"] {
-  color: #0ad666;
+  color: var(--success);
 }
 
 #dice-box .displayResults .results strong[data-success="false"],
 #dice-result-sharing-box .displayResults .results strong[data-success="false"] {
-  color: #ff4848;
+  color: var(--danger);
 }
 
 #dice-canvas {
@@ -571,12 +576,12 @@ button:active {
 
 .editable-md-widget .dice-notation {
   cursor: pointer;
-  color: #9773e4;
+  color: var(--link);
   font-weight: bold;
 }
 
 .editable-md-widget .dice-notation:hover {
-  color: #c9b0ff;
+  color: var(--link-hover);
 }
 
 .file-system {
@@ -595,7 +600,7 @@ button:active {
     opacity 0.5s;
   border: 3px solid transparent;
   border-radius: 8px;
-  background-color: #4c396e;
+  background-color: var(--surface);
   cursor: pointer;
   padding: 0.5rem;
   max-width: 204px;
@@ -603,25 +608,25 @@ button:active {
   font-family: inherit;
   font-size: 1em;
   font-weight: 500;
-  fill: #fff;
+  fill: var(--white);
 }
 
 .file-system .react-grid-item:hover {
-  border-color: #b9f;
+  border-color: var(--primary-light);
 }
 
 .file-system .react-grid-item:active {
-  background-color: #8447ff;
+  background-color: var(--primary);
 }
 
 .file-system .react-grid-placeholder {
-  background-color: #5e5e5e;
+  background-color: var(--grid-placeholder);
   padding: 0;
 }
 
 .file-system .react-grid-item.folder {
   box-sizing: border-box;
-  background-color: #7a583e;
+  background-color: var(--folder);
   clip-path: polygon(0 23%,
       0 7%,
       4% 0,
@@ -643,7 +648,7 @@ button:active {
   left: 1px;
   /* Match border width */
   z-index: -1;
-  background-color: #7a583e;
+  background-color: var(--folder);
   /* Same as the folder color */
   width: calc(100% - 3px);
   /* Compensate for left & right borders */
@@ -666,32 +671,32 @@ button:active {
 
 .file-system .react-grid-item.folder:hover {
   border-color: transparent;
-  background-color: #d6beae;
+  background-color: var(--folder-hover);
 }
 
 .file-system .react-grid-item.moveFolderUp {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #ad5252;
+  background-color: var(--danger);
 }
 
 .file-system .react-grid-item.moveFolderUp:hover {
-  border-color: #ff9c9c;
+  border-color: var(--primary-light);
 }
 
 .file-system .react-grid-item.moveFolderUp img {
   width: 26px;
 }
 
-@media (prefers-color-scheme: light) {
+html[data-theme="light"] {
   :root {
-    background-color: #dfcffc;
-    color: #000;
+    background-color: var(--bg);
+    color: var(--black);
   }
 
   .editable-md-widget {
-    --basePageBg: #f0e9e9;
+    --basePageBg: var(--surface-alt);
     --admonitionTipBg: hsl(187deg 71% 88%);
     --admonitionTipBorder: hsl(189deg 60% 53%);
     --admonitionInfoBg: hsl(123deg 45% 90%);
@@ -705,12 +710,12 @@ button:active {
   }
 
   button {
-    background-color: #b9f;
-    color: #000;
+    background-color: var(--primary-light);
+    color: var(--black);
   }
 
   button.icon-button {
-    background-color: #b9f;
+    background-color: var(--primary-light);
   }
 
   button.icon-button img {
@@ -723,15 +728,15 @@ button:active {
   }
 
   button:hover {
-    border-color: #8447ff;
+    border-color: var(--primary);
   }
 
   button.icon-button:hover {
-    border-color: #8447ff;
+    border-color: var(--primary);
   }
 
   .react-grid-layout {
-    background-color: #999999;
+    background-color: var(--grid-bg);
   }
 
   .react-grid-layout.file-system {
@@ -739,7 +744,7 @@ button:active {
   }
 
   .react-grid-layout .react-grid-item#add-widget {
-    background-color: #8447ff;
+    background-color: var(--primary);
   }
 
   .react-grid-layout .react-grid-item#add-widget img {
@@ -747,13 +752,13 @@ button:active {
   }
 
   .react-grid-layout .react-grid-item {
-    border: 2px solid #4c2696;
-    background-color: #ffffff;
+    border: 2px solid var(--primary-dark);
+    background-color: var(--white);
   }
 
   .react-grid-item>.react-resizable-handle::after {
-    border-right: 2px solid #8447ff;
-    border-bottom: 2px solid #8447ff;
+    border-right: 2px solid var(--primary);
+    border-bottom: 2px solid var(--primary);
   }
 
   .react-grid-layout .react-grid-item #delete-widget img {
@@ -763,76 +768,76 @@ button:active {
   .editable-md-widget span,
   .editable-md-widget strong,
   .editable-md-widget em {
-    color: #000;
+    color: var(--black);
   }
 
   .editable-md-widget code span,
   .editable-md-widget code strong,
   .editable-md-widget code em {
-    background-color: #656565;
-    color: #fff;
+    background-color: var(--code-bg);
+    color: var(--white);
   }
 
   .editable-md-widget a span,
   .editable-md-widget a strong,
   .editable-md-widget a em {
-    color: #8447ff;
+    color: var(--primary);
   }
 
   .editable-md-widget a span:hover,
   .editable-md-widget a strong:hover,
   .editable-md-widget a em:hover {
-    color: #9773e4;
+    color: var(--link);
   }
 
   .editable-md-widget a code span,
   .editable-md-widget a code strong,
   .editable-md-widget a code em {
-    color: #8447ff;
+    color: var(--primary);
   }
 
   .editable-md-widget ul,
   .editable-md-widget ol {
-    color: #000;
+    color: var(--black);
   }
 
   .editable-md-widget .dice-notation {
-    color: #8447ff;
+    color: var(--primary);
   }
 
   .editable-md-widget .dice-notation:hover {
-    color: #4c2696;
+    color: var(--primary-dark);
   }
 
   .file-system .react-grid-item {
     border: 3px solid transparent;
-    background-color: #b9f;
-    fill: #000;
+    background-color: var(--primary-light);
+    fill: var(--black);
   }
 
   .file-system .react-grid-item:hover {
-    border-color: #8447ff;
+    border-color: var(--primary);
   }
 
   .file-system .react-grid-item svg {
-    fill: #000;
+    fill: var(--black);
   }
 
   .file-system .react-grid-item.folder {
-    background-color: #927745;
+    background-color: var(--folder);
   }
 
   .file-system .react-grid-item.folder::after {
-    background-color: #eed6a8;
+    background-color: var(--primary-light);
   }
 
   .file-system .react-grid-item.folder:hover {
     border-color: transparent;
-    background-color: #ffb835;
+    background-color: var(--folder-hover);
   }
 
   .file-system .react-grid-item.moveFolderUp {
-    background-color: #ff9c9c;
+    background-color: var(--primary-light);
   }
 
   .file-system .react-grid-item.moveFolderUp img {
@@ -840,14 +845,14 @@ button:active {
   }
 
   .file-system .react-grid-item.moveFolderUp:hover {
-    border-color: #ad5252;
+    border-color: var(--danger);
   }
 
   .mdxeditor-popup-container>div:has(div[class^="_linkDialogPopoverContent"])>div button[class^="_actionButton"] {
-    background-color: #4c396e;
+    background-color: var(--surface);
   }
 
   .mdxeditor-popup-container>div:has(div[class^="_linkDialogPopoverContent"])>div a[class^="_linkDialogPreviewAnchor"]:hover {
-    border: 2px solid #8447ff;
+    border: 2px solid var(--primary);
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,15 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import { AppProvider } from "./AppProvider.tsx";
 import "./dbInstance.ts";
+import "./styles/theme.css";
 import "./index.css";
+
+const themeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+const setTheme = (e: MediaQueryList | MediaQueryListEvent) => {
+  document.documentElement.setAttribute("data-theme", e.matches ? "dark" : "light");
+};
+setTheme(themeQuery);
+themeQuery.addEventListener("change", setTheme);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/styles/ColumnToggle.module.css
+++ b/src/styles/ColumnToggle.module.css
@@ -1,3 +1,4 @@
+/* Column toggle switch colours use --primary for slider background */
 .columnToggle-label {
   display: inline-block;
   position: relative;
@@ -17,7 +18,7 @@
   inset: 0;
   transition: 0.4s;
   border-radius: 34px;
-  background-color: #8447ff;
+  background-color: var(--primary);
   cursor: pointer;
 }
 

--- a/src/styles/Dashboard.module.css
+++ b/src/styles/Dashboard.module.css
@@ -1,3 +1,6 @@
+/* Dashboard layout styling
+   --bg and --surface control navigation colors
+   --primary variables affect button highlights */
 .dashboard {
   display: flex;
   flex-direction: column;
@@ -12,7 +15,7 @@
   justify-content: space-between;
   z-index: 1;
   margin-top: -8px;
-  background: #242424;
+  background: var(--bg);
   padding: 8px 0 12px;
   width: 97.5vw;
 }
@@ -48,7 +51,7 @@
   justify-content: center;
   transition: max-height 0.5s ease-out;
   border-radius: 8px;
-  background-color: #312544;
+  background-color: var(--surface);
   max-height: 0;
   overflow: hidden;
   text-align: center;
@@ -86,7 +89,7 @@
   top: 68px;
   justify-content: center;
   z-index: 1;
-  background-color: #242424;
+  background-color: var(--bg);
   padding-bottom: 10px;
 }
 
@@ -98,7 +101,7 @@
 
 .dashboard-toolbar-zone {
   /* Using --baseBorderHover for the disabled styling of undo/redo buttons */
-  --baseBorderHover: #ba98ff8a;
+  --baseBorderHover: var(--border)8a;
 
   display: flex;
   justify-content: space-evenly;
@@ -108,7 +111,7 @@
     background-color 0.25s;
   border: 3px solid transparent;
   border-radius: 8px;
-  background-color: #4c396e;
+  background-color: var(--surface);
   width: 100%;
   min-height: 40px;
 }
@@ -122,11 +125,11 @@
 }
 
 .dashboard-toolbar-zone button {
-  color: #ceb6fe;
+  color: var(--link-hover);
 }
 
 .dashboard-toolbar-zone:hover {
-  border-color: #ba98ff;
+  border-color: var(--border);
 }
 
 .dashboard-toolbar-zone>* {
@@ -146,30 +149,30 @@
   height: auto;
 }
 
-@media (prefers-color-scheme: light) {
+html[data-theme="light"] {
   .dashboard-nav {
-    background: #dfcffc;
+    background: var(--bg);
   }
 
   .dashboard-toolbar-container {
-    background-color: #dfcffc;
+    background-color: var(--bg);
   }
 
   .dashboard-toolbar-zone {
-    --baseBorderHover: #ceb6fe84;
-    background-color: #b9f;
+    --baseBorderHover: var(--link-hover)84;
+    background-color: var(--primary-light);
   }
 
   .dashboard-toolbar-zone:hover {
-    border-color: #8447ff;
+    border-color: var(--primary);
   }
 
   .dashboard-toolbar-zone button {
-    color: #4c2696;
+    color: var(--primary-dark);
   }
 
   .dashboard-toolbar-zone button[data-disabled] svg {
-    color: #9773e4;
+    color: var(--link);
   }
 
   .dashboard-toolbar-zone button[data-state="on"] {
@@ -184,14 +187,14 @@
   .dashboard-duplicate-zone,
   .dashboard-columntoggle-zone,
   .dashboard-share-zone {
-    background-color: #b9f;
+    background-color: var(--primary-light);
   }
 
   .dashboard-delete-zone button,
   .dashboard-duplicate-zone button,
   .dashboard-columntoggle-zone button,
   .dashboard-share-zone button {
-    background-color: #8447ff;
+    background-color: var(--primary);
     color: white;
   }
 
@@ -199,6 +202,6 @@
   .dashboard-duplicate-zone button:hover,
   .dashboard-columntoggle-zone button:hover,
   .dashboard-share-zone button:hover {
-    border-color: #4c2696;
+    border-color: var(--primary-dark);
   }
 }

--- a/src/styles/FolderCreator.module.css
+++ b/src/styles/FolderCreator.module.css
@@ -1,10 +1,11 @@
+/* Folder creator uses --folder and --primary-light for button colors */
 .folder-creator {
   display: flex;
   align-items: center;
 }
 
 .folder-creator-button {
-  background-color: #7a583e;
+  background-color: var(--folder);
   padding: 0.25rem;
 }
 
@@ -13,18 +14,18 @@
 }
 
 .folder-creator-button:hover {
-  border-color: #d6beae;
+  border-color: var(--folder-hover);
 }
 
-@media (prefers-color-scheme: light) {
+html[data-theme="light"] {
   .folder-creator-button {
-    background-color: #eed6a8;
-    border-color: #927745;
+    background-color: var(--primary-light);
+    border-color: var(--folder);
     padding: 0.25rem;
   }
 
   .folder-creator-button:hover {
-    border-color: #ffb835;
+    border-color: var(--folder-hover);
   }
 
   .folder-creator-button img {
@@ -54,13 +55,13 @@
 
 .folder-creator-breadcrumb-link {
   cursor: pointer;
-  color: #9d73f1;
+  color: var(--link);
   font-weight: 600;
 }
 
-@media (prefers-color-scheme: light) {
+html[data-theme="light"] {
   .folder-creator-breadcrumb-link {
-    color: #4c2696;
+    color: var(--primary-dark);
   }
 }
 
@@ -81,9 +82,9 @@
   width: 20px;
 }
 
-@media (prefers-color-scheme: light) {
+html[data-theme="light"] {
   .folder-creator-delete-folder {
-    background-color: #b9f;
+    background-color: var(--primary-light);
   }
 
   .folder-creator-delete-folder img {
@@ -98,7 +99,7 @@
   justify-content: center;
   transition: max-height 0.3s ease-out;
   border-radius: 8px;
-  background-color: #312544;
+  background-color: var(--surface);
   max-height: 0;
   overflow: hidden;
   text-align: center;

--- a/src/styles/PopOver.module.css
+++ b/src/styles/PopOver.module.css
@@ -1,3 +1,4 @@
+/* PopOver styles rely on --white and --black for icon colors */
 .pop-over h1 img {
   position: relative;
   top: 4px;
@@ -47,12 +48,12 @@
 }
 
 .dashboard-input-selections button svg {
-  fill: #fff;
+  fill: var(--white);
 }
 
-@media (prefers-color-scheme: light) {
+html[data-theme="light"] {
   .dashboard-input-selections button svg {
-    fill: #000;
+    fill: var(--black);
   }
 }
 
@@ -69,7 +70,7 @@
   height: 20px;
 }
 
-@media (prefers-color-scheme: light) {
+html[data-theme="light"] {
   .dashboard-info-link img {
     filter: brightness(0);
   }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,69 @@
+/*
+  Theme variables controlling UI colors.
+  --bg: page background
+  --text: main text color
+  --surface: generic surface background
+  --surface-alt: alternative background used inside widgets
+  --border: border color for interactive elements
+  --primary: primary accent color
+  --primary-light: lighter accent used for hover states
+  --primary-dark: darker accent used for active states
+  --success: success color for dice results
+  --danger: error color for dice results
+  --folder: base folder color
+  --folder-hover: folder hover color
+*/
+
+[data-theme='dark'] {
+  --bg: #242424;
+  --text: #fff;
+  --surface: #4c396e;
+  --surface-alt: #3a3a3a;
+  --grid-bg: #5f5f5f;
+  --border: #ba98ff;
+  --primary: #8447ff;
+  --primary-light: #b9f;
+  --primary-dark: #4c2696;
+  --primary-darker: #2b194f;
+  --success: #0ad666;
+  --danger: #ff4848;
+  --folder: #7a583e;
+  --folder-hover: #d6beae;
+  --grid-placeholder: #5e5e5e;
+  --white: #ffffff;
+  --black: #000;
+  --link: #9773e4;
+  --link-hover: #c9b0ff;
+  --toolbar-border-hover: #ba98ff8a;
+  --code-bg: #656565;
+  --link-dialog-label: #d2bff9;
+  --dice-label: #ffcf91;
+  --dice-fill: #dcf;
+}
+
+[data-theme='light'] {
+  --bg: #dfcffc;
+  --text: #000;
+  --surface: #b9f;
+  --surface-alt: #f0e9e9;
+  --grid-bg: #999999;
+  --border: #8447ff;
+  --primary: #8447ff;
+  --primary-light: #b9f;
+  --primary-dark: #4c2696;
+  --primary-darker: #4c2696;
+  --success: #0ad666;
+  --danger: #ff4848;
+  --folder: #927745;
+  --folder-hover: #ffb835;
+  --grid-placeholder: #5e5e5e;
+  --white: #ffffff;
+  --black: #000;
+  --link: #8447ff;
+  --link-hover: #9773e4;
+  --toolbar-border-hover: #ceb6fe84;
+  --code-bg: #656565;
+  --link-dialog-label: #d2bff9;
+  --dice-label: #ffcf91;
+  --dice-fill: #dcf;
+}


### PR DESCRIPTION
## Summary
- introduce `theme.css` with dark/light variables
- import theme file and set `data-theme` based on system preference
- replace hardcoded colors with CSS variables in all styles
- swap `prefers-color-scheme` media queries for `data-theme` selectors
- document variable usage with comments

## Testing
- `npm run lint` *(fails: React hook warning)*

------
https://chatgpt.com/codex/tasks/task_e_68727484b4d8832eb9f9edbb399f8f64