### PR TITLE
download and upload whole folders

### DIFF
--- a/src/components/FolderCreator.tsx
+++ b/src/components/FolderCreator.tsx
@@ -1,9 +1,12 @@
 import { useRef, useState } from "react";
 
 import AddFolderIcon from "../assets/addFolder.svg?react";
+import DownloadIcon from "../assets/download.svg?react";
 import FireIcon from "../assets/fire.svg?react";
 import {
+  buildFolderExport,
   findAllDashboardsWithinCurrentFolderStruc,
+  generateLayouts,
   getCurrentFolder,
   getSurroundings,
 } from "../functions";
@@ -55,10 +58,10 @@ export const FolderCreator = ({
       return;
     }
 
-    // Don't allow the name "Home"
-    if (newFolderName === "Home") {
+    // Don't allow reserved names
+    if (newFolderName === "Home" || newFolderName === "Premades") {
       folderInput.setCustomValidity(
-        "Sorry, can't call it \"Home\". That's a reserved keyword I'm using.",
+        `Sorry, can't call it "${newFolderName}". That's a reserved keyword I'm using.`,
       );
       folderInput.reportValidity();
       return;
@@ -111,23 +114,16 @@ export const FolderCreator = ({
           acc.push(
             <a
               title={`Click to go to ${curr}`}
-              key={curr}
+              key={`breadcrumb-${index}`}
               className={styles["folder-creator-breadcrumb-link"]}
               onClick={() => {
                 setMenuObject((prevMenuObj) => {
                   const newMenuObj = structuredClone(prevMenuObj);
-                  if (curr === "Home") {
+                  if (index === 0) {
                     newMenuObj.currentFolder = [];
                   } else {
-                    // When Selected Folder is Clicked, remove all currentFolder array entries to the right of the selected folder.
-                    const indexOfSelectedFolder =
-                      newMenuObj.currentFolder.indexOf(curr);
-                    indexOfSelectedFolder !== -1 &&
-                      (newMenuObj.currentFolder =
-                        newMenuObj.currentFolder.slice(
-                          0,
-                          indexOfSelectedFolder + 1,
-                        ));
+                    newMenuObj.currentFolder =
+                      newMenuObj.currentFolder.slice(0, index);
                   }
                   return newMenuObj;
                 });
@@ -140,7 +136,7 @@ export const FolderCreator = ({
         } else {
           acc.push(
             <span
-              key={curr}
+              key={`breadcrumb-${index}`}
               className={styles["folder-creator-breadcrumb-current"]}
             >
               {curr}
@@ -149,7 +145,7 @@ export const FolderCreator = ({
         }
 
         if (!isLast) {
-          acc.push(<span key={`${curr}-span`}> → </span>);
+          acc.push(<span key={`breadcrumb-${index}-sep`}> → </span>);
         }
 
         return acc;
@@ -158,6 +154,29 @@ export const FolderCreator = ({
     );
 
     return breadcrumb;
+  };
+
+  const handleDownloadFolder = async () => {
+    const currentInd = menuObject.currentFolder;
+    if (currentInd.length === 0) return;
+
+    const folderName = currentInd[currentInd.length - 1];
+    const currentFolder = getCurrentFolder(menuObject);
+
+    const folderExport = await buildFolderExport(
+      folderName,
+      currentFolder as Folder,
+    );
+    const jsonString = JSON.stringify(folderExport);
+    const blob = new Blob([jsonString], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${folderName}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
   };
 
   const handleDeleteFolder = () => {
@@ -186,6 +205,17 @@ export const FolderCreator = ({
 
         newMenuObj.currentFolder.pop();
 
+        // Regenerate layouts so moved-up dashboards are interactive
+        const goUpButton =
+          newMenuObj.currentFolder.length !== 0
+            ? ["MoveDashUpButton"]
+            : [];
+        parentFolder.layouts = generateLayouts([
+          ...goUpButton,
+          ...Object.keys(parentFolder.folders || {}),
+          ...(parentFolder.dashboards || []),
+        ]);
+
         return newMenuObj;
       });
 
@@ -209,6 +239,8 @@ export const FolderCreator = ({
 
   if (menuObject) {
     const isInsideAFolder = menuObject.currentFolder.length !== 0;
+    const isInsidePremades =
+      menuObject.currentFolder.includes("Premades");
 
     return (
       <>
@@ -243,19 +275,34 @@ export const FolderCreator = ({
               <div className={styles["folder-creator-breadcrumb"]}>
                 {generateFolderBreadCrumb()}
               </div>
-              <button
-                className={styles["folder-creator-delete-folder"]}
-                title="Delete this folder."
-                onClick={() => setDeleteZoneIsOpen((prev) => !prev)}
-              >
-                {/* <img alt="Delete Icon" src={fire}></img> */}
-                <FireIcon
-                  className="icon-svg-fire"
-                  style={{
-                    width: "20px",
-                  }}
-                />
-              </button>
+              <div style={{ display: "flex", gap: "4px" }}>
+                {!isInsidePremades && (
+                  <button
+                    className={styles["folder-creator-download-folder"]}
+                    title="Download this folder."
+                    onClick={handleDownloadFolder}
+                  >
+                    <DownloadIcon
+                      className="icon-svg-download"
+                      style={{
+                        width: "20px",
+                      }}
+                    />
+                  </button>
+                )}
+                <button
+                  className={styles["folder-creator-delete-folder"]}
+                  title="Delete this folder."
+                  onClick={() => setDeleteZoneIsOpen((prev) => !prev)}
+                >
+                  <FireIcon
+                    className="icon-svg-fire"
+                    style={{
+                      width: "20px",
+                    }}
+                  />
+                </button>
+              </div>
             </div>
             <div
               className={`${styles["folder-delete-zone"]} ${

--- a/src/components/PopOver.tsx
+++ b/src/components/PopOver.tsx
@@ -4,7 +4,12 @@ import DashboardIcon from "../assets/dashboard.svg?react";
 import RefreshIcon from "../assets/refresh.svg?react";
 import UploadIcon from "../assets/upload.svg?react";
 import db from "../dbInstance";
-import { getCurrentFolder, validateUpload } from "../functions";
+import {
+  getCurrentFolder,
+  importFolderExport,
+  validateFolderUpload,
+  validateUpload,
+} from "../functions";
 import {
   useAppStore,
   useInitDashboards,
@@ -15,6 +20,7 @@ import {
 import styles from "../styles/PopOver.module.css";
 import type {
   DashboardItemsProps,
+  FolderExport,
   MenuObject,
   NewDashboardTemplateOptions,
   PopOverProps,
@@ -159,23 +165,75 @@ const PopOver = memo(({ standalone = false, role }: PopOverProps) => {
   const handleUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files && event.target.files[0];
     if (file) {
-      const dashboardName = file.name.replace(".json", "");
-      if (dashBoardsArray.includes(dashboardName)) {
-        uploadRef!.current!.setCustomValidity("");
-        uploadRef!.current!.setCustomValidity(
-          "The Dashboard Name Must Be Unique. Rename the file!",
-        );
-        uploadRef!.current!.reportValidity();
-        event.target.value = "";
-      } else {
-        uploadRef!.current!.setCustomValidity("");
-        const reader = new FileReader();
-        reader.onload = async (e) => {
-          const text = e.target && e.target.result;
-          try {
-            const uploadedDashboard: DashboardItemsProps = JSON.parse(
-              text as string,
+      uploadRef!.current!.setCustomValidity("");
+      const reader = new FileReader();
+      reader.onload = async (e) => {
+        const text = e.target && e.target.result;
+        try {
+          const parsed = JSON.parse(text as string);
+
+          if (parsed?.type === "folder-export") {
+            // Folder import path
+            const isValidFolder = validateFolderUpload(parsed);
+            if (!isValidFolder) {
+              uploadRef!.current!.setCustomValidity("Invalid Folder File!");
+              uploadRef!.current!.reportValidity();
+              event.target.value = "";
+              return;
+            }
+
+            // Validate each dashboard inside the folder export
+            const folderExport = parsed as FolderExport;
+            for (const dashData of Object.values(folderExport.dashboards)) {
+              if (!validateUpload(dashData)) {
+                uploadRef!.current!.setCustomValidity(
+                  "Folder contains invalid dashboard data!",
+                );
+                uploadRef!.current!.reportValidity();
+                event.target.value = "";
+                return;
+              }
+            }
+
+            const currentFolder = getCurrentFolder(menuObject);
+            const existingFolderNames = Object.keys(
+              currentFolder.folders ?? {},
             );
+
+            const { folderName, folder, newDashNames } =
+              await importFolderExport(
+                folderExport,
+                dashBoardsArray,
+                existingFolderNames,
+              );
+
+            for (const name of newDashNames) {
+              updateDashboardsState(name, "add");
+            }
+
+            setMenuObject((prevMenuObj) => {
+              const newMenuObj: MenuObject = structuredClone(prevMenuObj);
+              const current = getCurrentFolder(newMenuObj);
+              if (!current.folders) {
+                current.folders = {};
+              }
+              current.folders[folderName] = folder;
+              return newMenuObj;
+            });
+            setSyncStorage((prev) => prev + 1);
+          } else {
+            // Single dashboard import path
+            const dashboardName = file.name.replace(".json", "");
+            if (dashBoardsArray.includes(dashboardName)) {
+              uploadRef!.current!.setCustomValidity(
+                "The Dashboard Name Must Be Unique. Rename the file!",
+              );
+              uploadRef!.current!.reportValidity();
+              event.target.value = "";
+              return;
+            }
+
+            const uploadedDashboard: DashboardItemsProps = parsed;
             const isValidDashboard = validateUpload(uploadedDashboard);
             if (isValidDashboard) {
               await db.setItem(dashboardName, uploadedDashboard);
@@ -193,27 +251,24 @@ const PopOver = memo(({ standalone = false, role }: PopOverProps) => {
                 return newMenuObj;
               });
             } else {
-              uploadRef!.current!.setCustomValidity("");
               uploadRef!.current!.setCustomValidity("Invalid Dashboard File!");
             }
-          } catch (e) {
-            console.error("Error parsing JSON:", e);
-            uploadRef!.current!.setCustomValidity("");
-            uploadRef!.current!.setCustomValidity("Error Reading the file.");
-          } finally {
-            uploadRef!.current!.reportValidity();
-            event.target.value = "";
           }
-        };
-        reader.onerror = () => {
-          // To debug, check for reader.error
-          uploadRef!.current!.setCustomValidity("");
-          uploadRef!.current!.setCustomValidity("Error Uploading the file.");
+        } catch (e) {
+          console.error("Error parsing JSON:", e);
+          uploadRef!.current!.setCustomValidity("Error Reading the file.");
+        } finally {
           uploadRef!.current!.reportValidity();
           event.target.value = "";
-        };
-        reader.readAsText(file);
-      }
+        }
+      };
+      reader.onerror = () => {
+        uploadRef!.current!.setCustomValidity("");
+        uploadRef!.current!.setCustomValidity("Error Uploading the file.");
+        uploadRef!.current!.reportValidity();
+        event.target.value = "";
+      };
+      reader.readAsText(file);
     }
   };
 
@@ -270,7 +325,7 @@ const PopOver = memo(({ standalone = false, role }: PopOverProps) => {
               <button
                 className="icon-button"
                 id="upload-button"
-                title="Upload a Dashboard."
+                title="Upload a Dashboard or Folder."
                 onClick={() => handleUploadClick()}
               >
                 <UploadIcon

--- a/src/functions/folderFunctions.ts
+++ b/src/functions/folderFunctions.ts
@@ -1,4 +1,11 @@
-import type { Folder, FolderSystem, MenuObject } from "../types";
+import db from "../dbInstance";
+import type {
+  DashboardItemsProps,
+  Folder,
+  FolderExport,
+  FolderSystem,
+  MenuObject,
+} from "../types";
 
 export const getCurrentFolder = (menuObject: MenuObject) => {
   if (menuObject.currentFolder.length === 0) {
@@ -65,4 +72,98 @@ export const findAllDashboardsWithinCurrentFolderStruc = (
     [],
   );
   return allDashboards;
+};
+
+export const buildFolderExport = async (
+  folderName: string,
+  folder: Folder,
+): Promise<FolderExport> => {
+  const allDashNames = recursiveSearchFoldersForDashboards(folder, []);
+  const dashboards: { [dashName: string]: DashboardItemsProps } = {};
+
+  for (const name of allDashNames) {
+    const data: DashboardItemsProps | null = await db.getItem(name);
+    if (data) {
+      dashboards[name] = data;
+    }
+  }
+
+  return {
+    type: "folder-export",
+    name: folderName,
+    folderStructure: folder,
+    dashboards,
+  };
+};
+
+const getUniqueName = (name: string, existingNames: Set<string>): string => {
+  if (!existingNames.has(name)) return name;
+  let counter = 2;
+  while (existingNames.has(`${name} (${counter})`)) {
+    counter++;
+  }
+  return `${name} (${counter})`;
+};
+
+const renameDashboardsInFolder = (
+  folder: Folder,
+  renameMap: Map<string, string>,
+): Folder => {
+  const result: Folder = { ...folder };
+
+  if (result.dashboards) {
+    result.dashboards = result.dashboards.map(
+      (name) => renameMap.get(name) ?? name,
+    );
+  }
+
+  if (result.folders) {
+    const newFolders: FolderSystem = {};
+    for (const key in result.folders) {
+      newFolders[key] = renameDashboardsInFolder(
+        result.folders[key],
+        renameMap,
+      );
+    }
+    result.folders = newFolders;
+  }
+
+  return result;
+};
+
+export const importFolderExport = async (
+  folderExport: FolderExport,
+  existingDashNames: string[],
+  existingFolderNames: string[],
+): Promise<{ folderName: string; folder: Folder; newDashNames: string[] }> => {
+  const existingDashSet = new Set(existingDashNames);
+  const existingFolderSet = new Set(existingFolderNames);
+
+  // Resolve folder name collision
+  const folderName = getUniqueName(folderExport.name, existingFolderSet);
+
+  // Resolve dashboard name collisions and build rename map
+  const renameMap = new Map<string, string>();
+  for (const originalName of Object.keys(folderExport.dashboards)) {
+    const newName = getUniqueName(originalName, existingDashSet);
+    if (newName !== originalName) {
+      renameMap.set(originalName, newName);
+    }
+    existingDashSet.add(newName);
+  }
+
+  // Update folder structure with renamed dashboards
+  const folder = renameMap.size > 0
+    ? renameDashboardsInFolder(folderExport.folderStructure, renameMap)
+    : folderExport.folderStructure;
+
+  // Write all dashboards to DB
+  const newDashNames: string[] = [];
+  for (const [originalName, data] of Object.entries(folderExport.dashboards)) {
+    const finalName = renameMap.get(originalName) ?? originalName;
+    await db.setItem(finalName, data);
+    newDashNames.push(finalName);
+  }
+
+  return { folderName, folder, newDashNames };
 };

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,9 +1,11 @@
-export { validateUpload } from "./validateUpload";
+export { validateUpload, validateFolderUpload } from "./validateUpload";
 export { generateLayouts } from "./generateLayouts";
 export {
   getCurrentFolder,
   getSurroundings,
   findAllDashboardsWithinCurrentFolderStruc,
+  buildFolderExport,
+  importFolderExport,
 } from "./folderFunctions";
 export { checkAndAddPremades, applyPremades } from "./premadesFunctions";
 export { collisionInfo } from "./collisions";

--- a/src/functions/validateUpload.ts
+++ b/src/functions/validateUpload.ts
@@ -30,3 +30,27 @@ const schema = {
 };
 
 export const validateUpload = ajv.compile(schema); // Compile the schema to a validation function
+
+const folderExportSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  properties: {
+    type: {
+      type: "string",
+      const: "folder-export",
+    },
+    name: {
+      type: "string",
+    },
+    folderStructure: {
+      type: "object",
+    },
+    dashboards: {
+      type: "object",
+    },
+  },
+  required: ["type", "name", "folderStructure", "dashboards"],
+  additionalProperties: false,
+};
+
+export const validateFolderUpload = ajv.compile(folderExportSchema);

--- a/src/styles/FolderCreator.module.css
+++ b/src/styles/FolderCreator.module.css
@@ -49,6 +49,10 @@
   font-weight: 900;
 }
 
+.folder-creator-download-folder {
+  padding: 0.5rem;
+}
+
 .folder-creator-delete-folder {
   padding: 0.5rem;
   margin-right: 0;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -112,3 +112,12 @@ export type AppContextProps = {
 export type AppProviderProps = {
   children: ReactElement | ReactElement[];
 };
+
+export type FolderExport = {
+  type: "folder-export";
+  name: string;
+  folderStructure: Folder;
+  dashboards: {
+    [dashName: string]: DashboardItemsProps;
+  };
+};


### PR DESCRIPTION
This feature allows for downloading / uploading of whole folders and the dashboards they contain. It turns this off for the "Premades" folder - cause there's other folder regenerating logic in there that gets wonky with folder uploading.