### PR TITLE
fix rendering issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# MCP config
+.mcp.json
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/ActiveToolbarContext.ts
+++ b/src/ActiveToolbarContext.ts
@@ -1,0 +1,5 @@
+import { createContext, type MutableRefObject } from "react";
+
+export const ActiveToolbarContext = createContext<MutableRefObject<string>>(
+  { current: "" } as MutableRefObject<string>,
+);

--- a/src/components/CustomToolbar.tsx
+++ b/src/components/CustomToolbar.tsx
@@ -12,21 +12,20 @@ import {
   inFocus$,
   useCellValue,
 } from "@mdxeditor/editor";
-import { memo, useEffect, useState } from "react";
+import { memo, useContext, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
+import { ActiveToolbarContext } from "../ActiveToolbarContext";
 import type { TextAlignment as Alignment } from "../types";
 import { TextAlignment } from "./TextAlignment";
 
 type CustomToolbarProps = {
-  activeToolbarKey: string;
-  setActiveToolbarKey: (key: string) => void;
   updateWidgetTextAlignment: (itemId: string, alignment: Alignment) => void;
 };
 
 export const CustomToolbar = memo((props: CustomToolbarProps) => {
-  const { activeToolbarKey, setActiveToolbarKey, updateWidgetTextAlignment } =
-    props;
+  const { updateWidgetTextAlignment } = props;
+  const activeToolbarKeyRef = useContext(ActiveToolbarContext);
   const activeEditor = useCellValue(activeEditor$);
   const inFocus = useCellValue(inFocus$);
   const [showToolbar, setShowToolbar] = useState(false);
@@ -35,26 +34,33 @@ export const CustomToolbar = memo((props: CustomToolbarProps) => {
     useState<Alignment>("center");
 
   useEffect(() => {
-    if (activeEditor) {
-      if (activeToolbarKey !== activeEditor._key) {
-        if (inFocus) {
-          const rootEL = activeEditor._rootElement;
-          // Yikes.
-          const gridItem =
-            rootEL?.parentElement?.parentElement?.parentElement?.parentElement
-              ?.parentElement;
-          const gridItemId = gridItem?.id as string;
-          const gridItemTextAlign = gridItem?.dataset.align as Alignment;
-          setActiveGridItemId(gridItemId);
-          setActiveGridItemTextAlign(gridItemTextAlign);
-          setActiveToolbarKey(activeEditor._key);
-          setShowToolbar(true);
-        } else {
+    if (!activeEditor) return;
+
+    if (inFocus) {
+      activeToolbarKeyRef.current = activeEditor._key;
+      const rootEL = activeEditor._rootElement;
+      // Yikes.
+      const gridItem =
+        rootEL?.parentElement?.parentElement?.parentElement?.parentElement
+          ?.parentElement;
+      const gridItemId = gridItem?.id as string;
+      const gridItemTextAlign = gridItem?.dataset.align as Alignment;
+      setActiveGridItemId(gridItemId);
+      setActiveGridItemTextAlign(gridItemTextAlign);
+      setShowToolbar(true);
+    } else {
+      // Defer the hide check so that if another editor's effect claims
+      // the ref first (gaining focus), this toolbar will see the new
+      // owner and hide. If no one else claims it (e.g. toolbar button
+      // click), the toolbar stays visible.
+      const timeout = setTimeout(() => {
+        if (activeToolbarKeyRef.current !== activeEditor._key) {
           setShowToolbar(false);
         }
-      }
+      }, 0);
+      return () => clearTimeout(timeout);
     }
-  }, [activeEditor, activeToolbarKey, inFocus, setActiveToolbarKey]);
+  }, [activeEditor, inFocus, activeToolbarKeyRef]);
 
   return showToolbar ? (
     <>

--- a/src/components/SyncingGrid.tsx
+++ b/src/components/SyncingGrid.tsx
@@ -4,11 +4,13 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   useTransition,
 } from "react";
 import { Responsive, WidthProvider } from "react-grid-layout";
 
+import { ActiveToolbarContext } from "../ActiveToolbarContext";
 import CrossIcon from "../assets/cross.svg?react";
 import db from "../dbInstance";
 import startingLayouts from "../partials/startingLayout";
@@ -50,7 +52,7 @@ const SyncingGrid = memo(
     );
     const [widgets, setWidgets] = useState<WidgetProps[] | null>(null);
     const [syncStorage, setSyncStorage] = useState(0);
-    const [activeToolbarKey, setActiveToolbarKey] = useState<string>("");
+    const activeToolbarKeyRef = useRef("");
 
     useEffect(() => {
       const getSavedItems = async () => {
@@ -243,8 +245,6 @@ const SyncingGrid = memo(
                   item={item}
                   updateWidgetContent={updateWidgetContent}
                   updateWidgetTextAlignment={updateWidgetTextAlignment}
-                  activeToolbarKey={activeToolbarKey}
-                  setActiveToolbarKey={setActiveToolbarKey}
                 />
               </div>
               <span
@@ -268,7 +268,6 @@ const SyncingGrid = memo(
     }, [
       isLocked,
       widgets,
-      activeToolbarKey,
       addNewWidget,
       deleteWidget,
       updateWidgetContent,
@@ -286,7 +285,7 @@ const SyncingGrid = memo(
     }, [columns]);
 
     return (
-      <>
+      <ActiveToolbarContext.Provider value={activeToolbarKeyRef}>
         {isPending ? (
           <div className="lds-ellipsis">
             <div></div>
@@ -312,7 +311,7 @@ const SyncingGrid = memo(
             )}
           </>
         )}
-      </>
+      </ActiveToolbarContext.Provider>
     );
   },
 );

--- a/src/components/Widget.tsx
+++ b/src/components/Widget.tsx
@@ -26,8 +26,6 @@ type WidgetContainerProps = {
   item: WidgetProps;
   updateWidgetContent: (item: WidgetProps, content: string) => void;
   updateWidgetTextAlignment: (itemId: string, alignment: TextAlignment) => void;
-  activeToolbarKey: string;
-  setActiveToolbarKey: (key: string) => void;
 };
 
 const Widget = memo(
@@ -35,8 +33,6 @@ const Widget = memo(
     item,
     updateWidgetContent,
     updateWidgetTextAlignment,
-    activeToolbarKey,
-    setActiveToolbarKey,
   }: WidgetContainerProps) => {
     const debouncedUpdate = debounce((content: string) => {
       return updateWidgetContent(item, content);
@@ -77,8 +73,6 @@ const Widget = memo(
             toolbarContents: () => (
               <>
                 <CustomToolbar
-                  activeToolbarKey={activeToolbarKey}
-                  setActiveToolbarKey={setActiveToolbarKey}
                   updateWidgetTextAlignment={updateWidgetTextAlignment}
                 />
               </>


### PR DESCRIPTION
## Bug Fix: Ping-Pong Render Loop Between MDXEditor Instances

### Overview

When multiple MDXEditor widgets were on the same dashboard, clicking between editors (especially after clicking a dice notation) could trigger a semi-infinite render loop. Two editors would continuously steal "active toolbar" status from each other, causing rapid re-renders until the user clicked outside all editors.

**Root cause:** `activeToolbarKey` was stored as React state in `SyncingGrid`, passed as a prop through `Widget` to `CustomToolbar`. When any toolbar called `setActiveToolbarKey`, it triggered a re-render of `SyncingGrid`, which recomputed `memoizedChildren`, re-rendered all `Widget`/`MDXEditor` instances, and could shift focus between editors — causing another toolbar to claim the key, and so on.

**Fix:** Replaced the state-based `activeToolbarKey` with a `useRef`, shared via React Context. Mutating a ref is invisible to React's render cycle, so changing the active toolbar key no longer triggers re-renders in any component. Each `CustomToolbar` now only reacts to its own editor's focus changes, with a deferred hide check (`setTimeout(0)`) to ensure proper ordering when switching between editors.

### Files Changed

- **`src/ActiveToolbarContext.ts`** (added) — Creates a React Context that provides a `MutableRefObject<string>` for the active toolbar key.
- **`src/components/SyncingGrid.tsx`** — Replaced `useState` for `activeToolbarKey` with `useRef`. Wraps the grid in `ActiveToolbarContext.Provider`. Removed `activeToolbarKey` from `Widget` props and `memoizedChildren` dependency array.
- **`src/components/Widget.tsx`** — Removed `activeToolbarKey` and `setActiveToolbarKey` from props. `CustomToolbar` no longer receives these as props.
- **`src/components/CustomToolbar.tsx`** — Reads the toolbar key ref from `ActiveToolbarContext` via `useContext`. Rewrote the `useEffect` to claim the ref on focus and defer the hide check with `setTimeout(0)`, eliminating cross-toolbar effect chains.
- **`.gitignore`** — Added `.mcp.json`.

